### PR TITLE
Hide next button function added

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var result = document.getElementById("result");
 var hint = document.getElementById("hint");
 var tries = 0;
 
+/** Next button */
+var nextButton = document.querySelector(".next-pattern");
+
 /** The numbers array gets its values from whichever function is called */
 var numbers = [];
 
@@ -88,8 +91,17 @@ function displayPattern() {
 displayPattern();
 
 // Checks the users input against the last (hidden) element in the array
+
+// Change the initial style to none
+nextButton.style.display = "none";
+
 function guess() {
     tries++;
+
+    if (tries == 3) {
+        nextButton.style.display = "inline-block";
+    }
+
     if (nextNumber.value == numbers[numbers.length-1]) {
         result.innerHTML = "You win!";
         hint.innerHTML = "";
@@ -104,10 +116,12 @@ function guess() {
 
 // Function to call the next pattern
 function nextPattern() {
+    tries = 0;
     result.innerHTML = "";
     hint.style.display = "none";
     document.getElementById("display-pattern").innerHTML = "";
     numbers = [];
+    nextButton.style.display = "none";
     callRandomFunction();
     displayPattern();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added functionality where the "next" button is invisible until the user makes three attempts or hits the question. After that the button is visible again and the user can skip the question.

## Motivation and Context
It fixes an open issue: https://github.com/jemimaabu/find-the-formula/issues/5

## How Has This Been Tested?
I tested this on localhost. I did several tests on situations passing me by a user to check if there was any situation where the user could cause some error.

## Screenshots (if appropriate):
![screenshot_2](https://user-images.githubusercontent.com/44846329/51781103-87e01300-20fb-11e9-8468-2d6e4b1c72a3.png)
![screenshot_3](https://user-images.githubusercontent.com/44846329/51781108-90384e00-20fb-11e9-9dbb-6614d2afa72f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
